### PR TITLE
Potential issue in imgui/imgui.cpp: Unchecked return from initialization function

### DIFF
--- a/imgui/imgui.cpp
+++ b/imgui/imgui.cpp
@@ -5463,7 +5463,7 @@ static bool ImGui::UpdateManualResize(ImGuiWindow* window, const ImVec2& size_au
         if (resize_rect.Min.x > resize_rect.Max.x) ImSwap(resize_rect.Min.x, resize_rect.Max.x);
         if (resize_rect.Min.y > resize_rect.Max.y) ImSwap(resize_rect.Min.y, resize_rect.Max.y);
         resize_rect.ClipWith(clip_viewport_rect);
-        bool hovered, held;
+        bool hovered = false, held = false;
         ButtonBehavior(resize_rect, window->GetID((void*)(intptr_t)resize_grip_n), &hovered, &held, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_NoNavFocus);
         //GetForegroundDrawList(window)->AddRect(resize_rect.Min, resize_rect.Max, IM_COL32(255, 255, 0, 255));
         if (hovered || held)
@@ -5488,7 +5488,7 @@ static bool ImGui::UpdateManualResize(ImGuiWindow* window, const ImVec2& size_au
     }
     for (int border_n = 0; border_n < resize_border_count; border_n++)
     {
-        bool hovered, held;
+        bool hovered = false, held = false;
         ImRect border_rect = GetResizeBorderRect(window, border_n, grip_hover_inner_size, WINDOWS_RESIZE_FROM_EDGES_HALF_THICKNESS);
         border_rect.ClipWith(clip_viewport_rect);
         ButtonBehavior(border_rect, window->GetID((void*)(intptr_t)(border_n + 4)), &hovered, &held, ImGuiButtonFlags_FlattenChildren);
@@ -12825,7 +12825,7 @@ static void ImGui::DockNodeUpdateTabBar(ImGuiDockNode* node, ImGuiWindow* host_w
     ImGuiID title_bar_id = host_window->GetID("#TITLEBAR");
     if (g.HoveredId == 0 || g.HoveredId == title_bar_id || g.ActiveId == title_bar_id)
     {
-        bool held;
+        bool held = false;
         ButtonBehavior(title_bar_rect, title_bar_id, NULL, &held);
         if (held)
         {


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**3 instances** of this defect were found in the following locations:

---
**Instance 1**
File : `imgui/imgui.cpp` 
Enclosing Function : `UpdateManualResize@ImGui`
Function : `ButtonBehavior@ImGui` 
https://github.com/siva-msft/putils/blob/6bfeca82b55ca194ccf6ab43353c9b3b1a8be76f/imgui/imgui.cpp#L5467
**Issue in**: _held, hovered_

**Code extract**:

```cpp
        if (resize_rect.Min.y > resize_rect.Max.y) ImSwap(resize_rect.Min.y, resize_rect.Max.y);
        resize_rect.ClipWith(clip_viewport_rect);
        bool hovered, held;
        ButtonBehavior(resize_rect, window->GetID((void*)(intptr_t)resize_grip_n), &hovered, &held, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_NoNavFocus); <------ HERE
        //GetForegroundDrawList(window)->AddRect(resize_rect.Min, resize_rect.Max, IM_COL32(255, 255, 0, 255));
        if (hovered || held)
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 2**
File : `imgui/imgui.cpp` 
Enclosing Function : `UpdateManualResize@ImGui`
Function : `ButtonBehavior@ImGui` 
https://github.com/siva-msft/putils/blob/6bfeca82b55ca194ccf6ab43353c9b3b1a8be76f/imgui/imgui.cpp#L5494
**Issue in**: _held, hovered_

**Code extract**:

```cpp
        bool hovered, held;
        ImRect border_rect = GetResizeBorderRect(window, border_n, grip_hover_inner_size, WINDOWS_RESIZE_FROM_EDGES_HALF_THICKNESS);
        border_rect.ClipWith(clip_viewport_rect);
        ButtonBehavior(border_rect, window->GetID((void*)(intptr_t)(border_n + 4)), &hovered, &held, ImGuiButtonFlags_FlattenChildren); <------ HERE
        //GetForegroundDrawList(window)->AddRect(border_rect.Min, border_rect.Max, IM_COL32(255, 255, 0, 255));
        if ((hovered && g.HoveredIdTimer > WINDOWS_RESIZE_FROM_EDGES_FEEDBACK_TIMER) || held)
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 3**
File : `imgui/imgui.cpp` 
Enclosing Function : `DockNodeUpdateTabBar@ImGui`
Function : `ButtonBehavior@ImGui` 
https://github.com/siva-msft/putils/blob/6bfeca82b55ca194ccf6ab43353c9b3b1a8be76f/imgui/imgui.cpp#L12829
**Issue in**: _held_

**Code extract**:

```cpp
    if (g.HoveredId == 0 || g.HoveredId == title_bar_id || g.ActiveId == title_bar_id)
    {
        bool held;
        ButtonBehavior(title_bar_rect, title_bar_id, NULL, &held); <------ HERE
        if (held)
        {
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
