### PR TITLE
Potential issue in imgui/imgui_widgets.cpp: Unchecked return from initialization function

### DIFF
--- a/imgui/imgui_widgets.cpp
+++ b/imgui/imgui_widgets.cpp
@@ -1311,7 +1311,7 @@ bool ImGui::SplitterBehavior(const ImRect& bb, ImGuiID id, ImGuiAxis axis, float
     if (!item_add)
         return false;
 
-    bool hovered, held;
+    bool hovered = false, held = false;
     ImRect bb_interact = bb;
     bb_interact.Expand(axis == ImGuiAxis_Y ? ImVec2(0.0f, hover_extend) : ImVec2(hover_extend, 0.0f));
     ButtonBehavior(bb_interact, id, &hovered, &held, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_AllowItemOverlap);


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**2 instances** of this defect were found in the following locations:

---
**Instance 1**
File : `imgui/imgui_widgets.cpp` 
Enclosing Function : `SplitterBehavior@ImGui`
Function : `ButtonBehavior@ImGui` 
https://github.com/siva-msft/putils/blob/6bfeca82b55ca194ccf6ab43353c9b3b1a8be76f/imgui/imgui_widgets.cpp#L1317
**Issue in**: _held, hovered_

**Code extract**:

```cpp
    bool hovered, held;
    ImRect bb_interact = bb;
    bb_interact.Expand(axis == ImGuiAxis_Y ? ImVec2(0.0f, hover_extend) : ImVec2(hover_extend, 0.0f));
    ButtonBehavior(bb_interact, id, &hovered, &held, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_AllowItemOverlap); <------ HERE
    if (g.ActiveId != id)
        SetItemAllowOverlap();
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 2**
File : `imgui/imgui_widgets.cpp` 
Enclosing Function : `DataTypeApplyOpFromText@ImGui`
Function : `sscanf` 
https://github.com/siva-msft/putils/blob/6bfeca82b55ca194ccf6ab43353c9b3b1a8be76f/imgui/imgui_widgets.cpp#L1845
**Issue in**: _v32_

**Code extract**:

```cpp
    {
        // Small types need a 32-bit buffer to receive the result from scanf()
        int v32;
        sscanf(buf, format, &v32); <------ HERE
        if (data_type == ImGuiDataType_S8)
            *(ImS8*)data_ptr = (ImS8)ImClamp(v32, (int)IM_S8_MIN, (int)IM_S8_MAX);
```

**How can I fix it?** 
Correct reference usage found in `imgui/imgui_widgets.cpp` at line `1828`.
https://github.com/siva-msft/putils/blob/6bfeca82b55ca194ccf6ab43353c9b3b1a8be76f/imgui/imgui_widgets.cpp#L1828
**Code extract**:

```cpp
        double arg0f = *v, arg1f = 0.0;
        if (op && sscanf(initial_value_buf, format, &arg0f) < 1)
            return false;
        if (sscanf(buf, format, &arg1f) < 1) <------ HERE
            return false;
        if (op == '+')      { *v = arg0f + arg1f; }                    // Add (use "+-" to subtract)
```

